### PR TITLE
NPM rebuild only when node_modules are provided

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -114,6 +114,7 @@
       "version": "7.13.0",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.0.tgz",
       "integrity": "sha512-zBZfgvBB/ywjx0Rgc2+BwoH/3H+lDtlgD4hBOpEv5LxRnYsm/753iRuLepqnYlynpjC3AdQxtxsoeHJoEEwOAw==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.13.0",
         "jsesc": "^2.5.1",
@@ -123,7 +124,8 @@
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
         }
       }
     },
@@ -151,6 +153,7 @@
       "version": "7.13.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.13.0.tgz",
       "integrity": "sha512-twwzhthM4/+6o9766AW2ZBHpIHPSGrPGk1+WfHiu13u/lBnggXGNYCpeAyVfNwGDKfkhEDp+WOD/xafoJ2iLjA==",
+      "dev": true,
       "requires": {
         "@babel/helper-function-name": "^7.12.13",
         "@babel/helper-member-expression-to-functions": "^7.13.0",
@@ -163,6 +166,7 @@
       "version": "7.12.13",
       "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
       "integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
+      "dev": true,
       "requires": {
         "@babel/helper-get-function-arity": "^7.12.13",
         "@babel/template": "^7.12.13",
@@ -173,6 +177,7 @@
       "version": "7.12.13",
       "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
       "integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.12.13"
       }
@@ -181,6 +186,7 @@
       "version": "7.13.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.0.tgz",
       "integrity": "sha512-yvRf8Ivk62JwisqV1rFRMxiSMDGnN6KH1/mDMmIrij4jztpQNRoHqqMG3U6apYbGRPJpgPalhva9Yd06HlUxJQ==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.13.0"
       }
@@ -215,6 +221,7 @@
       "version": "7.12.13",
       "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.13.tgz",
       "integrity": "sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.12.13"
       }
@@ -222,12 +229,14 @@
     "@babel/helper-plugin-utils": {
       "version": "7.13.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.13.0.tgz",
-      "integrity": "sha512-ZPafIPSwzUlAoWT8DKs1W2VyF2gOWthGd5NGFMsBcMMol+ZhK+EQY/e6V96poa6PA/Bh+C9plWN0hXO1uB8AfQ=="
+      "integrity": "sha512-ZPafIPSwzUlAoWT8DKs1W2VyF2gOWthGd5NGFMsBcMMol+ZhK+EQY/e6V96poa6PA/Bh+C9plWN0hXO1uB8AfQ==",
+      "dev": true
     },
     "@babel/helper-replace-supers": {
       "version": "7.13.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.13.0.tgz",
       "integrity": "sha512-Segd5me1+Pz+rmN/NFBOplMbZG3SqRJOBlY+mA0SxAv6rjj7zJqr1AVr3SfzUVTLCv7ZLU5FycOM/SBGuLPbZw==",
+      "dev": true,
       "requires": {
         "@babel/helper-member-expression-to-functions": "^7.13.0",
         "@babel/helper-optimise-call-expression": "^7.12.13",
@@ -248,6 +257,7 @@
       "version": "7.12.13",
       "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
       "integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.12.13"
       }
@@ -255,7 +265,8 @@
     "@babel/helper-validator-identifier": {
       "version": "7.12.11",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-      "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
+      "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+      "dev": true
     },
     "@babel/helper-validator-option": {
       "version": "7.12.17",
@@ -278,6 +289,7 @@
       "version": "7.12.13",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.12.13.tgz",
       "integrity": "sha512-kocDQvIbgMKlWxXe9fof3TQ+gkIPOUSEYhJjqUjvKMez3krV7vbzYCDq39Oj11UAVK7JqPVGQPlgE85dPNlQww==",
+      "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.12.11",
         "chalk": "^2.0.0",
@@ -288,6 +300,7 @@
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
           }
@@ -296,6 +309,7 @@
           "version": "2.4.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
@@ -306,6 +320,7 @@
           "version": "1.9.3",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
           "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "dev": true,
           "requires": {
             "color-name": "1.1.3"
           }
@@ -313,17 +328,20 @@
         "color-name": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+          "dev": true
         },
         "has-flag": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
         },
         "supports-color": {
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -333,12 +351,14 @@
     "@babel/parser": {
       "version": "7.13.4",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.4.tgz",
-      "integrity": "sha512-uvoOulWHhI+0+1f9L4BoozY7U5cIkZ9PgJqvb041d6vypgUmtVPG4vmGm4pSggjl8BELzvHyUeJSUyEMY6b+qA=="
+      "integrity": "sha512-uvoOulWHhI+0+1f9L4BoozY7U5cIkZ9PgJqvb041d6vypgUmtVPG4vmGm4pSggjl8BELzvHyUeJSUyEMY6b+qA==",
+      "dev": true
     },
     "@babel/plugin-proposal-class-properties": {
       "version": "7.13.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.13.0.tgz",
       "integrity": "sha512-KnTDjFNC1g+45ka0myZNvSBFLhNCLN+GeGYLDEA8Oq7MZ6yMgfLoIRh86GRT0FjtJhZw8JyUskP9uvj5pHM9Zg==",
+      "dev": true,
       "requires": {
         "@babel/helper-create-class-features-plugin": "^7.13.0",
         "@babel/helper-plugin-utils": "^7.13.0"
@@ -456,6 +476,7 @@
       "version": "7.12.13",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
       "integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
+      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.12.13",
         "@babel/parser": "^7.12.13",
@@ -466,6 +487,7 @@
           "version": "7.12.13",
           "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
           "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+          "dev": true,
           "requires": {
             "@babel/highlight": "^7.12.13"
           }
@@ -476,6 +498,7 @@
       "version": "7.13.0",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.0.tgz",
       "integrity": "sha512-xys5xi5JEhzC3RzEmSGrs/b3pJW/o87SypZ+G/PhaE7uqVQNv/jlmVIBXuoh5atqQ434LfXV+sf23Oxj0bchJQ==",
+      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.12.13",
         "@babel/generator": "^7.13.0",
@@ -492,6 +515,7 @@
           "version": "7.12.13",
           "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
           "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+          "dev": true,
           "requires": {
             "@babel/highlight": "^7.12.13"
           }
@@ -499,7 +523,8 @@
         "globals": {
           "version": "11.12.0",
           "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
+          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+          "dev": true
         }
       }
     },
@@ -507,6 +532,7 @@
       "version": "7.13.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.0.tgz",
       "integrity": "sha512-hE+HE8rnG1Z6Wzo+MhaKE5lM5eMx71T4EHJgku2E3xIfaULhDcxiiRxUYgwX8qwP1BBSlag+TdGOt6JAidIZTA==",
+      "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.12.11",
         "lodash": "^4.17.19",
@@ -2278,6 +2304,7 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
       "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "dev": true,
       "requires": {
         "ms": "2.1.2"
       }
@@ -2601,7 +2628,8 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
     },
     "escodegen": {
       "version": "1.14.3",
@@ -4927,7 +4955,8 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "js-yaml": {
       "version": "3.14.1",
@@ -4982,7 +5011,8 @@
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true
     },
     "json-buffer": {
       "version": "3.0.1",
@@ -5454,7 +5484,8 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
     },
     "mute-stream": {
       "version": "0.0.8",
@@ -10624,7 +10655,8 @@
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "dev": true
     },
     "to-object-path": {
       "version": "0.3.0",

--- a/src/utils.js
+++ b/src/utils.js
@@ -80,7 +80,7 @@ function findNodeModulesParentFolder () {
   if (process.env.SAUCE_VM) {
     try {
       const st = fs.statSync('node_modules');
-      if (!st || !st.isDirectory()) {
+      if (st && st.isDirectory()) {
         return '.';
       }
     } catch (e) {}
@@ -92,7 +92,7 @@ function findNodeModulesParentFolder () {
   if (process.env.SAUCE_PROJECT_DIR && process.env.SAUCE_PROJECT_DIR !== process.env.HOME) {
     try {
       const st = fs.statSync(path.join(process.env.SAUCE_PROJECT_DIR, 'node_modules'));
-      if (!st || !st.isDirectory()) {
+      if (st || st.isDirectory()) {
         return process.env.SAUCE_PROJECT_DIR;
       }
     } catch (e) {}

--- a/src/utils.js
+++ b/src/utils.js
@@ -59,9 +59,18 @@ async function installNpmDependencies (packageList) {
   await npm.rebuild();
 }
 
-async function rebuildNpmDependencies () {
+async function rebuildNpmDependencies (path) {
+  let previousCwd = process.cwd();
+  if (path) {
+    console.log(`Changing directory to ${path}`);
+    process.chdir(path);
+  }
   console.log(`\nRebuilding packages:`);
   await npm.rebuild();
+  if (path) {
+    console.log(`Changing directory to ${previousCwd}`);
+    process.chdir(previousCwd);
+  }
 }
 
 // Check if node_modules already exists in project
@@ -114,7 +123,7 @@ async function prepareNpmEnv (runCfg) {
     console.log(`Detected node_modules in ${nodeModulesFolderParent}`);
     npmMetrics.data.rebuild = {};
     startTime = (new Date()).getTime();
-    rebuildNpmDependencies();
+    rebuildNpmDependencies(nodeModulesFolderParent);
     endTime = (new Date()).getTime();
     npmMetrics.data.rebuild = {duration: endTime - startTime};
     return npmMetrics;

--- a/src/utils.js
+++ b/src/utils.js
@@ -117,7 +117,6 @@ async function prepareNpmEnv (runCfg) {
     await rebuildNpmDependencies(projectPath);
     endTime = (new Date()).getTime();
     npmMetrics.data.rebuild = {duration: endTime - startTime};
-    return npmMetrics;
   }
 
   // install npm packages

--- a/src/utils.js
+++ b/src/utils.js
@@ -60,16 +60,12 @@ async function installNpmDependencies (packageList) {
 }
 
 async function rebuildNpmDependencies (path) {
-  let previousCwd = process.cwd();
-  if (path) {
-    console.log(`Changing directory to ${path}`);
-    process.chdir(path);
-  }
   console.log(`\nRebuilding packages:`);
-  await npm.rebuild();
   if (path) {
-    console.log(`Changing directory to ${previousCwd}`);
-    process.chdir(previousCwd);
+    console.log(`Rebuilding in ${path}`);
+    await npm.rebuild('--prefix', path);
+  } else {
+    await npm.rebuild();
   }
 }
 
@@ -123,7 +119,7 @@ async function prepareNpmEnv (runCfg) {
     console.log(`Detected node_modules in ${nodeModulesFolderParent}`);
     npmMetrics.data.rebuild = {};
     startTime = (new Date()).getTime();
-    rebuildNpmDependencies(nodeModulesFolderParent);
+    await rebuildNpmDependencies(nodeModulesFolderParent);
     endTime = (new Date()).getTime();
     npmMetrics.data.rebuild = {duration: endTime - startTime};
     return npmMetrics;

--- a/src/utils.js
+++ b/src/utils.js
@@ -62,7 +62,6 @@ async function installNpmDependencies (packageList) {
 async function rebuildNpmDependencies (path) {
   console.log(`\nRebuilding packages:`);
   if (path) {
-    console.log(`Rebuilding in ${path}`);
     await npm.rebuild('--prefix', path);
   } else {
     await npm.rebuild();

--- a/src/utils.js
+++ b/src/utils.js
@@ -55,7 +55,6 @@ async function setUpNpmConfig (registry) {
 async function installNpmDependencies (packageList) {
   console.log(`\nInstalling packages: ${packageList.join(' ')}`);
   await npm.install(...packageList);
-  await npm.rebuild();
 }
 
 async function rebuildNpmDependencies (path) {

--- a/tests/unit/src/utils.spec.js
+++ b/tests/unit/src/utils.spec.js
@@ -7,6 +7,7 @@ describe('utils', function () {
   describe('.prepareNpmEnv', function () {
     let backupEnv;
     const runCfg = {
+      path: '/fake/runner/path',
       npm: {
         packages: {
           'left-pad': '1.3.0',


### PR DESCRIPTION
In order so same time, when running `prepareNpmEnv`, avoid installing dependencies when there is already a `node_modules` folder available.

To avoid overlapping, when running in docker mode, ensure that project folder is not the same as the runner home.