### PR TITLE
Prevent npm install from installing from package-lock.json

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,4 @@
+// vim: tabstop=2 shiftwidth=2 expandtab
 const path = require('path');
 const fs = require('fs');
 const _ = require('lodash');
@@ -39,26 +40,19 @@ function getDefaultRegistry () {
   return process.env.SAUCE_NPM_CACHE || DEFAULT_REGISTRY;
 }
 
-async function setUpNpmConfig (registry, strictSSL) {
+async function setUpNpmConfig (userConfig) {
   console.log('Preparing npm environment');
-  await npm.load({
-    registry,
+  const defaultConfig = {
     retry: { retries: 3 },
     json: false,
     save: false,
     audit: false,
     rollback: false,
     fund: false,
-    'strict-ssl': strictSSL,
     noproxy: 'registry.npmjs.org',
-    cafile: process.env.CA_FILE || null,
-    // https://docs.npmjs.com/cli/v6/using-npm/config#package-lock
-    // By default, `npm install $package` will install `$package` as well
-    // as any dependency defined in package-lock.json that is missing from
-    // node_modules.
-    // Setting to false means `npm install $package` only installs `$package`
-    'package-lock': false
-  });
+    cafile: process.env.CA_FILE || null
+  };
+  await npm.load(Object.assign({}, defaultConfig, userConfig));
 }
 
 async function installNpmDependencies (packageList) {
@@ -97,23 +91,32 @@ function hasNodeModulesFolder (runCfg) {
   return false;
 }
 
+function getNpmConfig (runnerConfig) {
+  return {
+    registry: runnerConfig.npm.registry || getDefaultRegistry(),
+    'strict-ssl': runnerConfig.npm.strictSSL !== false,
+    // https://docs.npmjs.com/cli/v6/using-npm/config#package-lock
+    // By default, `npm install $package` will install `$package` as well
+    // as any dependency defined in package-lock.json that is missing from
+    // node_modules.
+    // Setting to false means `npm install $package` only installs `$package`
+    'package-lock': runnerConfig.npm.packageLock === true
+  };
+}
+
 async function prepareNpmEnv (runCfg) {
   const npmMetrics = {
     name: 'npm_metrics.json', data: {}
   };
-  const npmConfig = runCfg && runCfg.npm && runCfg.npm.packages || {};
-  const packageList = Object.entries(npmConfig).map(([pkg, version]) => `${pkg}@${version}`);
-  if (packageList.length === 0) {
+  const packageList = runCfg && runCfg.npm && runCfg.npm.packages || {};
+  const npmPackages = Object.entries(packageList).map(([pkg, version]) => `${pkg}@${version}`);
+  if (npmPackages.length === 0) {
     return npmMetrics;
   }
-  // prepares npm config
-  const registry = runCfg.npm.registry || getDefaultRegistry();
-  let strictSSL = true; // strictSSL is true by default
-  if (runCfg.npm.strictSSL === false) {
-    strictSSL = false;
-  }
+
+  const npmConfig = getNpmConfig(runCfg);
   let startTime = (new Date()).getTime();
-  await setUpNpmConfig(registry, strictSSL);
+  await setUpNpmConfig(npmConfig);
   let endTime = (new Date()).getTime();
   npmMetrics.data.setup = {duration: endTime - startTime};
 
@@ -134,7 +137,7 @@ async function prepareNpmEnv (runCfg) {
   // install npm packages
   npmMetrics.data.install = {};
   startTime = (new Date()).getTime();
-  await installNpmDependencies(packageList);
+  await installNpmDependencies(npmPackages);
   endTime = (new Date()).getTime();
   npmMetrics.data.install = {duration: endTime - startTime};
   return npmMetrics;
@@ -214,5 +217,5 @@ function renameAsset ({specFile, oldFilePath, resultsFolder}) {
 module.exports = {
   getAbsolutePath, shouldRecordVideo, loadRunConfig,
   prepareNpmEnv, setUpNpmConfig, installNpmDependencies, rebuildNpmDependencies,
-  getArgs, getEnv, getSuite, renameScreenshot, renameAsset
+  getArgs, getEnv, getSuite, renameScreenshot, renameAsset, getNpmConfig
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -51,7 +51,13 @@ async function setUpNpmConfig (registry, strictSSL) {
     fund: false,
     'strict-ssl': strictSSL,
     noproxy: 'registry.npmjs.org',
-    cafile: process.env.CA_FILE || null
+    cafile: process.env.CA_FILE || null,
+    // https://docs.npmjs.com/cli/v6/using-npm/config#package-lock
+    // By default, `npm install $package` will install `$package` as well
+    // as any dependency defined in package-lock.json that is missing from
+    // node_modules.
+    // Setting to false means `npm install $package` only installs `$package`
+    'package-lock': false
   });
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -50,7 +50,10 @@ async function setUpNpmConfig (userConfig) {
     rollback: false,
     fund: false,
     noproxy: 'registry.npmjs.org',
-    cafile: process.env.CA_FILE || null
+    cafile: process.env.CA_FILE || null,
+    'package-lock': false,
+    'strict-ssl': true,
+    registry: getDefaultRegistry()
   };
   await npm.load(Object.assign({}, defaultConfig, userConfig));
 }
@@ -92,6 +95,9 @@ function hasNodeModulesFolder (runCfg) {
 }
 
 function getNpmConfig (runnerConfig) {
+  if (runnerConfig.npm === undefined) {
+    return {};
+  }
   return {
     registry: runnerConfig.npm.registry || getDefaultRegistry(),
     'strict-ssl': runnerConfig.npm.strictSSL !== false,

--- a/tests/unit/src/__snapshots__/utils.spec.js.snap
+++ b/tests/unit/src/__snapshots__/utils.spec.js.snap
@@ -25,6 +25,7 @@ Array [
     "fund": false,
     "json": false,
     "noproxy": "registry.npmjs.org",
+    "package-lock": false,
     "registry": "test.cafile",
     "retry": Object {
       "retries": 3,
@@ -44,6 +45,7 @@ Array [
     "fund": false,
     "json": false,
     "noproxy": "registry.npmjs.org",
+    "package-lock": false,
     "registry": "test.strictSSL.false",
     "retry": Object {
       "retries": 3,
@@ -63,6 +65,7 @@ Array [
     "fund": false,
     "json": false,
     "noproxy": "registry.npmjs.org",
+    "package-lock": false,
     "registry": "test.strictSSL.true",
     "retry": Object {
       "retries": 3,
@@ -88,6 +91,7 @@ Array [
     "fund": false,
     "json": false,
     "noproxy": "registry.npmjs.org",
+    "package-lock": false,
     "registry": "my.registry",
     "retry": Object {
       "retries": 3,
@@ -107,6 +111,7 @@ Array [
     "fund": false,
     "json": false,
     "noproxy": "registry.npmjs.org",
+    "package-lock": false,
     "registry": "https://registry.npmjs.org",
     "retry": Object {
       "retries": 3,
@@ -126,6 +131,7 @@ Array [
     "fund": false,
     "json": false,
     "noproxy": "registry.npmjs.org",
+    "package-lock": false,
     "registry": "npmland.io",
     "retry": Object {
       "retries": 3,
@@ -145,6 +151,7 @@ Array [
     "fund": false,
     "json": false,
     "noproxy": "registry.npmjs.org",
+    "package-lock": false,
     "registry": "https://registry.npmjs.org",
     "retry": Object {
       "retries": 3,
@@ -164,6 +171,7 @@ Array [
     "fund": false,
     "json": false,
     "noproxy": "registry.npmjs.org",
+    "package-lock": false,
     "registry": "https://registry.npmjs.org",
     "retry": Object {
       "retries": 3,
@@ -183,6 +191,7 @@ Array [
     "fund": false,
     "json": false,
     "noproxy": "registry.npmjs.org",
+    "package-lock": false,
     "registry": "registryland.io",
     "retry": Object {
       "retries": 3,

--- a/tests/unit/src/utils.spec.js
+++ b/tests/unit/src/utils.spec.js
@@ -24,6 +24,12 @@ describe('utils', function () {
       npm: {}
     };
 
+    it('should return empty dict when runner config is empty', function () {
+      const npmConfig = getNpmConfig({});
+
+      expect(npmConfig).toStrictEqual({});
+    });
+
     it('should set values when runner npm config is empty', function () {
       const npmConfig = getNpmConfig(emptyConfig);
 


### PR DESCRIPTION
## What
Set the `package-lock` npm config to `false`.

## Why
If there is a `package-lock.json` file in the current working directory, `npm install $package` will diff the dependency tree defined in `package-lock.json` and what's on disk in `node_modules` and automatically install every missing package as well `$package`. This is not the expected behaviour when defining packages in a saucectl config file and has undesirable side effects like trigger post-install scripts. e.g. cypress downloads its binary as a post-install script.

## Other notes
The one worry I have is the possibility that removing this unintended behaviour might break a user's tests. If a user has an incomplete list of test dependencies defined in their saucectl config, then removing the current behaviour could break their tests.