### PR TITLE
Fix test snapshots

### DIFF
--- a/tests/unit/src/__snapshots__/utils.spec.js.snap
+++ b/tests/unit/src/__snapshots__/utils.spec.js.snap
@@ -19,773 +19,177 @@ Object {
 
 exports[`utils .prepareNpmEnv should be able to set cafile 1`] = `
 Array [
-  Array [
-    Object {
-      "audit": false,
-      "cafile": null,
-      "fund": false,
-      "json": false,
-      "noproxy": "registry.npmjs.org",
-      "registry": "my.registry",
-      "retry": Object {
-        "retries": 3,
-      },
-      "rollback": false,
-      "save": false,
-      "strict-ssl": true,
+  Object {
+    "audit": false,
+    "cafile": "/fake/path",
+    "fund": false,
+    "json": false,
+    "noproxy": "registry.npmjs.org",
+    "registry": "test.cafile",
+    "retry": Object {
+      "retries": 3,
     },
-  ],
-  Array [
-    Object {
-      "audit": false,
-      "cafile": null,
-      "fund": false,
-      "json": false,
-      "noproxy": "registry.npmjs.org",
-      "registry": "npmland.io",
-      "retry": Object {
-        "retries": 3,
-      },
-      "rollback": false,
-      "save": false,
-      "strict-ssl": true,
-    },
-  ],
-  Array [
-    Object {
-      "audit": false,
-      "cafile": null,
-      "fund": false,
-      "json": false,
-      "noproxy": "registry.npmjs.org",
-      "registry": "registryland.io",
-      "retry": Object {
-        "retries": 3,
-      },
-      "rollback": false,
-      "save": false,
-      "strict-ssl": true,
-    },
-  ],
-  Array [
-    Object {
-      "audit": false,
-      "cafile": null,
-      "fund": false,
-      "json": false,
-      "noproxy": "registry.npmjs.org",
-      "registry": "registryland.io",
-      "retry": Object {
-        "retries": 3,
-      },
-      "rollback": false,
-      "save": false,
-      "strict-ssl": true,
-    },
-  ],
-  Array [
-    Object {
-      "audit": false,
-      "cafile": null,
-      "fund": false,
-      "json": false,
-      "noproxy": "registry.npmjs.org",
-      "registry": "registryland.io",
-      "retry": Object {
-        "retries": 3,
-      },
-      "rollback": false,
-      "save": false,
-      "strict-ssl": true,
-    },
-  ],
-  Array [
-    Object {
-      "audit": false,
-      "cafile": null,
-      "fund": false,
-      "json": false,
-      "noproxy": "registry.npmjs.org",
-      "registry": "test.strictSSL.null",
-      "retry": Object {
-        "retries": 3,
-      },
-      "rollback": false,
-      "save": false,
-      "strict-ssl": true,
-    },
-  ],
-  Array [
-    Object {
-      "audit": false,
-      "cafile": null,
-      "fund": false,
-      "json": false,
-      "noproxy": "registry.npmjs.org",
-      "registry": "test.strictSSL.false",
-      "retry": Object {
-        "retries": 3,
-      },
-      "rollback": false,
-      "save": false,
-      "strict-ssl": false,
-    },
-  ],
-  Array [
-    Object {
-      "audit": false,
-      "cafile": null,
-      "fund": false,
-      "json": false,
-      "noproxy": "registry.npmjs.org",
-      "registry": "test.strictSSL.true",
-      "retry": Object {
-        "retries": 3,
-      },
-      "rollback": false,
-      "save": false,
-      "strict-ssl": true,
-    },
-  ],
-  Array [
-    Object {
-      "audit": false,
-      "cafile": "/fake/path",
-      "fund": false,
-      "json": false,
-      "noproxy": "registry.npmjs.org",
-      "registry": "test.cafile",
-      "retry": Object {
-        "retries": 3,
-      },
-      "rollback": false,
-      "save": false,
-      "strict-ssl": true,
-    },
-  ],
+    "rollback": false,
+    "save": false,
+    "strict-ssl": true,
+  },
 ]
 `;
 
 exports[`utils .prepareNpmEnv should be able to set strictSSL to false 1`] = `
 Array [
-  Array [
-    Object {
-      "audit": false,
-      "cafile": null,
-      "fund": false,
-      "json": false,
-      "noproxy": "registry.npmjs.org",
-      "registry": "my.registry",
-      "retry": Object {
-        "retries": 3,
-      },
-      "rollback": false,
-      "save": false,
-      "strict-ssl": true,
+  Object {
+    "audit": false,
+    "cafile": null,
+    "fund": false,
+    "json": false,
+    "noproxy": "registry.npmjs.org",
+    "registry": "test.strictSSL.false",
+    "retry": Object {
+      "retries": 3,
     },
-  ],
-  Array [
-    Object {
-      "audit": false,
-      "cafile": null,
-      "fund": false,
-      "json": false,
-      "noproxy": "registry.npmjs.org",
-      "registry": "npmland.io",
-      "retry": Object {
-        "retries": 3,
-      },
-      "rollback": false,
-      "save": false,
-      "strict-ssl": true,
-    },
-  ],
-  Array [
-    Object {
-      "audit": false,
-      "cafile": null,
-      "fund": false,
-      "json": false,
-      "noproxy": "registry.npmjs.org",
-      "registry": "registryland.io",
-      "retry": Object {
-        "retries": 3,
-      },
-      "rollback": false,
-      "save": false,
-      "strict-ssl": true,
-    },
-  ],
-  Array [
-    Object {
-      "audit": false,
-      "cafile": null,
-      "fund": false,
-      "json": false,
-      "noproxy": "registry.npmjs.org",
-      "registry": "registryland.io",
-      "retry": Object {
-        "retries": 3,
-      },
-      "rollback": false,
-      "save": false,
-      "strict-ssl": true,
-    },
-  ],
-  Array [
-    Object {
-      "audit": false,
-      "cafile": null,
-      "fund": false,
-      "json": false,
-      "noproxy": "registry.npmjs.org",
-      "registry": "registryland.io",
-      "retry": Object {
-        "retries": 3,
-      },
-      "rollback": false,
-      "save": false,
-      "strict-ssl": true,
-    },
-  ],
-  Array [
-    Object {
-      "audit": false,
-      "cafile": null,
-      "fund": false,
-      "json": false,
-      "noproxy": "registry.npmjs.org",
-      "registry": "test.strictSSL.null",
-      "retry": Object {
-        "retries": 3,
-      },
-      "rollback": false,
-      "save": false,
-      "strict-ssl": true,
-    },
-  ],
-  Array [
-    Object {
-      "audit": false,
-      "cafile": null,
-      "fund": false,
-      "json": false,
-      "noproxy": "registry.npmjs.org",
-      "registry": "test.strictSSL.false",
-      "retry": Object {
-        "retries": 3,
-      },
-      "rollback": false,
-      "save": false,
-      "strict-ssl": false,
-    },
-  ],
+    "rollback": false,
+    "save": false,
+    "strict-ssl": false,
+  },
 ]
 `;
 
 exports[`utils .prepareNpmEnv should be able to set strictSSL to true 1`] = `
 Array [
-  Array [
-    Object {
-      "audit": false,
-      "cafile": null,
-      "fund": false,
-      "json": false,
-      "noproxy": "registry.npmjs.org",
-      "registry": "my.registry",
-      "retry": Object {
-        "retries": 3,
-      },
-      "rollback": false,
-      "save": false,
-      "strict-ssl": true,
+  Object {
+    "audit": false,
+    "cafile": null,
+    "fund": false,
+    "json": false,
+    "noproxy": "registry.npmjs.org",
+    "registry": "test.strictSSL.true",
+    "retry": Object {
+      "retries": 3,
     },
-  ],
-  Array [
-    Object {
-      "audit": false,
-      "cafile": null,
-      "fund": false,
-      "json": false,
-      "noproxy": "registry.npmjs.org",
-      "registry": "npmland.io",
-      "retry": Object {
-        "retries": 3,
-      },
-      "rollback": false,
-      "save": false,
-      "strict-ssl": true,
-    },
-  ],
-  Array [
-    Object {
-      "audit": false,
-      "cafile": null,
-      "fund": false,
-      "json": false,
-      "noproxy": "registry.npmjs.org",
-      "registry": "registryland.io",
-      "retry": Object {
-        "retries": 3,
-      },
-      "rollback": false,
-      "save": false,
-      "strict-ssl": true,
-    },
-  ],
-  Array [
-    Object {
-      "audit": false,
-      "cafile": null,
-      "fund": false,
-      "json": false,
-      "noproxy": "registry.npmjs.org",
-      "registry": "registryland.io",
-      "retry": Object {
-        "retries": 3,
-      },
-      "rollback": false,
-      "save": false,
-      "strict-ssl": true,
-    },
-  ],
-  Array [
-    Object {
-      "audit": false,
-      "cafile": null,
-      "fund": false,
-      "json": false,
-      "noproxy": "registry.npmjs.org",
-      "registry": "registryland.io",
-      "retry": Object {
-        "retries": 3,
-      },
-      "rollback": false,
-      "save": false,
-      "strict-ssl": true,
-    },
-  ],
-  Array [
-    Object {
-      "audit": false,
-      "cafile": null,
-      "fund": false,
-      "json": false,
-      "noproxy": "registry.npmjs.org",
-      "registry": "test.strictSSL.null",
-      "retry": Object {
-        "retries": 3,
-      },
-      "rollback": false,
-      "save": false,
-      "strict-ssl": true,
-    },
-  ],
-  Array [
-    Object {
-      "audit": false,
-      "cafile": null,
-      "fund": false,
-      "json": false,
-      "noproxy": "registry.npmjs.org",
-      "registry": "test.strictSSL.false",
-      "retry": Object {
-        "retries": 3,
-      },
-      "rollback": false,
-      "save": false,
-      "strict-ssl": false,
-    },
-  ],
-  Array [
-    Object {
-      "audit": false,
-      "cafile": null,
-      "fund": false,
-      "json": false,
-      "noproxy": "registry.npmjs.org",
-      "registry": "test.strictSSL.true",
-      "retry": Object {
-        "retries": 3,
-      },
-      "rollback": false,
-      "save": false,
-      "strict-ssl": true,
-    },
-  ],
+    "rollback": false,
+    "save": false,
+    "strict-ssl": true,
+  },
 ]
 `;
 
 exports[`utils .prepareNpmEnv should call npm install 1`] = `
 Array [
-  Array [
-    "mypackage@1.2.3",
-  ],
+  "mypackage@1.2.3",
 ]
 `;
 
 exports[`utils .prepareNpmEnv should set right registry for npm 1`] = `
 Array [
-  Array [
-    Object {
-      "audit": false,
-      "cafile": null,
-      "fund": false,
-      "json": false,
-      "noproxy": "registry.npmjs.org",
-      "registry": "my.registry",
-      "retry": Object {
-        "retries": 3,
-      },
-      "rollback": false,
-      "save": false,
-      "strict-ssl": true,
+  Object {
+    "audit": false,
+    "cafile": null,
+    "fund": false,
+    "json": false,
+    "noproxy": "registry.npmjs.org",
+    "registry": "my.registry",
+    "retry": Object {
+      "retries": 3,
     },
-  ],
+    "rollback": false,
+    "save": false,
+    "strict-ssl": true,
+  },
 ]
 `;
 
 exports[`utils .prepareNpmEnv should use default registry 1`] = `
 Array [
-  Array [
-    Object {
-      "audit": false,
-      "cafile": null,
-      "fund": false,
-      "json": false,
-      "noproxy": "registry.npmjs.org",
-      "registry": "my.registry",
-      "retry": Object {
-        "retries": 3,
-      },
-      "rollback": false,
-      "save": false,
-      "strict-ssl": true,
+  Object {
+    "audit": false,
+    "cafile": null,
+    "fund": false,
+    "json": false,
+    "noproxy": "registry.npmjs.org",
+    "registry": "https://registry.npmjs.org",
+    "retry": Object {
+      "retries": 3,
     },
-  ],
-  Array [
-    Object {
-      "audit": false,
-      "cafile": null,
-      "fund": false,
-      "json": false,
-      "noproxy": "registry.npmjs.org",
-      "registry": "npmland.io",
-      "retry": Object {
-        "retries": 3,
-      },
-      "rollback": false,
-      "save": false,
-      "strict-ssl": true,
-    },
-  ],
-  Array [
-    Object {
-      "audit": false,
-      "cafile": null,
-      "fund": false,
-      "json": false,
-      "noproxy": "registry.npmjs.org",
-      "registry": "registryland.io",
-      "retry": Object {
-        "retries": 3,
-      },
-      "rollback": false,
-      "save": false,
-      "strict-ssl": true,
-    },
-  ],
-  Array [
-    Object {
-      "audit": false,
-      "cafile": null,
-      "fund": false,
-      "json": false,
-      "noproxy": "registry.npmjs.org",
-      "registry": "registryland.io",
-      "retry": Object {
-        "retries": 3,
-      },
-      "rollback": false,
-      "save": false,
-      "strict-ssl": true,
-    },
-  ],
+    "rollback": false,
+    "save": false,
+    "strict-ssl": true,
+  },
 ]
 `;
 
 exports[`utils .prepareNpmEnv should use env var for registry 1`] = `
 Array [
-  Array [
-    Object {
-      "audit": false,
-      "cafile": null,
-      "fund": false,
-      "json": false,
-      "noproxy": "registry.npmjs.org",
-      "registry": "my.registry",
-      "retry": Object {
-        "retries": 3,
-      },
-      "rollback": false,
-      "save": false,
-      "strict-ssl": true,
+  Object {
+    "audit": false,
+    "cafile": null,
+    "fund": false,
+    "json": false,
+    "noproxy": "registry.npmjs.org",
+    "registry": "npmland.io",
+    "retry": Object {
+      "retries": 3,
     },
-  ],
-  Array [
-    Object {
-      "audit": false,
-      "cafile": null,
-      "fund": false,
-      "json": false,
-      "noproxy": "registry.npmjs.org",
-      "registry": "npmland.io",
-      "retry": Object {
-        "retries": 3,
-      },
-      "rollback": false,
-      "save": false,
-      "strict-ssl": true,
-    },
-  ],
+    "rollback": false,
+    "save": false,
+    "strict-ssl": true,
+  },
 ]
 `;
 
 exports[`utils .prepareNpmEnv should use true as the default value for strictSSL 1`] = `
 Array [
-  Array [
-    Object {
-      "audit": false,
-      "cafile": null,
-      "fund": false,
-      "json": false,
-      "noproxy": "registry.npmjs.org",
-      "registry": "my.registry",
-      "retry": Object {
-        "retries": 3,
-      },
-      "rollback": false,
-      "save": false,
-      "strict-ssl": true,
+  Object {
+    "audit": false,
+    "cafile": null,
+    "fund": false,
+    "json": false,
+    "noproxy": "registry.npmjs.org",
+    "registry": "https://registry.npmjs.org",
+    "retry": Object {
+      "retries": 3,
     },
-  ],
-  Array [
-    Object {
-      "audit": false,
-      "cafile": null,
-      "fund": false,
-      "json": false,
-      "noproxy": "registry.npmjs.org",
-      "registry": "npmland.io",
-      "retry": Object {
-        "retries": 3,
-      },
-      "rollback": false,
-      "save": false,
-      "strict-ssl": true,
-    },
-  ],
-  Array [
-    Object {
-      "audit": false,
-      "cafile": null,
-      "fund": false,
-      "json": false,
-      "noproxy": "registry.npmjs.org",
-      "registry": "registryland.io",
-      "retry": Object {
-        "retries": 3,
-      },
-      "rollback": false,
-      "save": false,
-      "strict-ssl": true,
-    },
-  ],
-  Array [
-    Object {
-      "audit": false,
-      "cafile": null,
-      "fund": false,
-      "json": false,
-      "noproxy": "registry.npmjs.org",
-      "registry": "registryland.io",
-      "retry": Object {
-        "retries": 3,
-      },
-      "rollback": false,
-      "save": false,
-      "strict-ssl": true,
-    },
-  ],
-  Array [
-    Object {
-      "audit": false,
-      "cafile": null,
-      "fund": false,
-      "json": false,
-      "noproxy": "registry.npmjs.org",
-      "registry": "registryland.io",
-      "retry": Object {
-        "retries": 3,
-      },
-      "rollback": false,
-      "save": false,
-      "strict-ssl": true,
-    },
-  ],
+    "rollback": false,
+    "save": false,
+    "strict-ssl": true,
+  },
 ]
 `;
 
 exports[`utils .prepareNpmEnv should use true as the default value for strictSSL if it's null in cfg 1`] = `
 Array [
-  Array [
-    Object {
-      "audit": false,
-      "cafile": null,
-      "fund": false,
-      "json": false,
-      "noproxy": "registry.npmjs.org",
-      "registry": "my.registry",
-      "retry": Object {
-        "retries": 3,
-      },
-      "rollback": false,
-      "save": false,
-      "strict-ssl": true,
+  Object {
+    "audit": false,
+    "cafile": null,
+    "fund": false,
+    "json": false,
+    "noproxy": "registry.npmjs.org",
+    "registry": "https://registry.npmjs.org",
+    "retry": Object {
+      "retries": 3,
     },
-  ],
-  Array [
-    Object {
-      "audit": false,
-      "cafile": null,
-      "fund": false,
-      "json": false,
-      "noproxy": "registry.npmjs.org",
-      "registry": "npmland.io",
-      "retry": Object {
-        "retries": 3,
-      },
-      "rollback": false,
-      "save": false,
-      "strict-ssl": true,
-    },
-  ],
-  Array [
-    Object {
-      "audit": false,
-      "cafile": null,
-      "fund": false,
-      "json": false,
-      "noproxy": "registry.npmjs.org",
-      "registry": "registryland.io",
-      "retry": Object {
-        "retries": 3,
-      },
-      "rollback": false,
-      "save": false,
-      "strict-ssl": true,
-    },
-  ],
-  Array [
-    Object {
-      "audit": false,
-      "cafile": null,
-      "fund": false,
-      "json": false,
-      "noproxy": "registry.npmjs.org",
-      "registry": "registryland.io",
-      "retry": Object {
-        "retries": 3,
-      },
-      "rollback": false,
-      "save": false,
-      "strict-ssl": true,
-    },
-  ],
-  Array [
-    Object {
-      "audit": false,
-      "cafile": null,
-      "fund": false,
-      "json": false,
-      "noproxy": "registry.npmjs.org",
-      "registry": "registryland.io",
-      "retry": Object {
-        "retries": 3,
-      },
-      "rollback": false,
-      "save": false,
-      "strict-ssl": true,
-    },
-  ],
-  Array [
-    Object {
-      "audit": false,
-      "cafile": null,
-      "fund": false,
-      "json": false,
-      "noproxy": "registry.npmjs.org",
-      "registry": "test.strictSSL.null",
-      "retry": Object {
-        "retries": 3,
-      },
-      "rollback": false,
-      "save": false,
-      "strict-ssl": true,
-    },
-  ],
+    "rollback": false,
+    "save": false,
+    "strict-ssl": true,
+  },
 ]
 `;
 
 exports[`utils .prepareNpmEnv should use user registry 1`] = `
 Array [
-  Array [
-    Object {
-      "audit": false,
-      "cafile": null,
-      "fund": false,
-      "json": false,
-      "noproxy": "registry.npmjs.org",
-      "registry": "my.registry",
-      "retry": Object {
-        "retries": 3,
-      },
-      "rollback": false,
-      "save": false,
-      "strict-ssl": true,
+  Object {
+    "audit": false,
+    "cafile": null,
+    "fund": false,
+    "json": false,
+    "noproxy": "registry.npmjs.org",
+    "registry": "registryland.io",
+    "retry": Object {
+      "retries": 3,
     },
-  ],
-  Array [
-    Object {
-      "audit": false,
-      "cafile": null,
-      "fund": false,
-      "json": false,
-      "noproxy": "registry.npmjs.org",
-      "registry": "npmland.io",
-      "retry": Object {
-        "retries": 3,
-      },
-      "rollback": false,
-      "save": false,
-      "strict-ssl": true,
-    },
-  ],
-  Array [
-    Object {
-      "audit": false,
-      "cafile": null,
-      "fund": false,
-      "json": false,
-      "noproxy": "registry.npmjs.org",
-      "registry": "registryland.io",
-      "retry": Object {
-        "retries": 3,
-      },
-      "rollback": false,
-      "save": false,
-      "strict-ssl": true,
-    },
-  ],
+    "rollback": false,
+    "save": false,
+    "strict-ssl": true,
+  },
 ]
 `;

--- a/tests/unit/src/utils.spec.js
+++ b/tests/unit/src/utils.spec.js
@@ -27,58 +27,58 @@ describe('utils', function () {
     });
     it('should set right registry for npm', async function () {
       await setUpNpmConfig('my.registry', true);
-      expect(npm.load.mock.calls).toMatchSnapshot();
+      expect(npm.load.mock.calls[npm.load.mock.calls.length - 1]).toMatchSnapshot();
     });
     it('should call npm install', async function () {
       await installNpmDependencies(['mypackage@1.2.3']);
-      expect(npm.install.mock.calls).toMatchSnapshot();
+      expect(npm.install.mock.calls[npm.install.mock.calls.length - 1]).toMatchSnapshot();
     });
     it('should use env var for registry', async function () {
       process.env.SAUCE_NPM_CACHE = 'npmland.io';
       await prepareNpmEnv(runCfg);
-      expect(npm.load.mock.calls).toMatchSnapshot();
+      expect(npm.load.mock.calls[npm.load.mock.calls.length - 1]).toMatchSnapshot();
     });
     it('should use user registry', async function () {
-      let cfg = _.clone(runCfg);
+      let cfg = _.cloneDeep(runCfg);
       cfg.npm.registry = 'registryland.io';
       await prepareNpmEnv(cfg);
-      expect(npm.load.mock.calls).toMatchSnapshot();
+      expect(npm.load.mock.calls[npm.load.mock.calls.length - 1]).toMatchSnapshot();
     });
     it('should use default registry', async function () {
       await prepareNpmEnv(runCfg);
-      expect(npm.load.mock.calls).toMatchSnapshot();
+      expect(npm.load.mock.calls[npm.load.mock.calls.length - 1]).toMatchSnapshot();
     });
     it('should use true as the default value for strictSSL', async function () {
       await prepareNpmEnv(runCfg);
-      expect(npm.load.mock.calls).toMatchSnapshot();
+      expect(npm.load.mock.calls[npm.load.mock.calls.length - 1]).toMatchSnapshot();
     });
     it('should use true as the default value for strictSSL if it\'s null in cfg', async function () {
-      let cfg = _.clone(runCfg);
+      let cfg = _.cloneDeep(runCfg);
       cfg.npm.strictSSL = null;
       cfg.npm.registry = 'test.strictSSL.null';
       await prepareNpmEnv(runCfg);
-      expect(npm.load.mock.calls).toMatchSnapshot();
+      expect(npm.load.mock.calls[npm.load.mock.calls.length - 1]).toMatchSnapshot();
     });
     it('should be able to set strictSSL to false', async function () {
-      let cfg = _.clone(runCfg);
+      let cfg = _.cloneDeep(runCfg);
       cfg.npm.strictSSL = false;
       cfg.npm.registry = 'test.strictSSL.false';
       await prepareNpmEnv(cfg);
-      expect(npm.load.mock.calls).toMatchSnapshot();
+      expect(npm.load.mock.calls[npm.load.mock.calls.length - 1]).toMatchSnapshot();
     });
     it('should be able to set strictSSL to true', async function () {
-      let cfg = _.clone(runCfg);
+      let cfg = _.cloneDeep(runCfg);
       cfg.npm.strictSSL = true;
       cfg.npm.registry = 'test.strictSSL.true';
       await prepareNpmEnv(cfg);
-      expect(npm.load.mock.calls).toMatchSnapshot();
+      expect(npm.load.mock.calls[npm.load.mock.calls.length - 1]).toMatchSnapshot();
     });
     it('should be able to set cafile', async function () {
-      let cfg = _.clone(runCfg);
+      let cfg = _.cloneDeep(runCfg);
       cfg.npm.registry = 'test.cafile';
       process.env.CA_FILE = '/fake/path';
       await prepareNpmEnv(cfg);
-      expect(npm.load.mock.calls).toMatchSnapshot();
+      expect(npm.load.mock.calls[npm.load.mock.calls.length - 1]).toMatchSnapshot();
     });
   });
   describe('.renameScreenshot', function () {


### PR DESCRIPTION
* match snapshots on the latest item in the mocked function calls
  collection. Other wise the match happens against every single mocked
  call and that makes failures incredibly difficult to locate.
* Use `_.deepClone` if manipulating the default test configuration.
  Failure to do so results in incorrect values in the generated
  snapshot. For example, the `utils .prepareNpmEnv should use default registry` test was testing the incorrect data because an earlier test overwrote the `npm.registry` in the default test config because it was using a **shallow** clone.
