### PR TITLE
chore: Remove cafile setting in utils

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -49,7 +49,6 @@ export async function setUpNpmConfig (nodeCtx: NodeContext, userConfig: NpmConfi
     audit: false,
     fund: false,
     noproxy: 'registry.npmjs.org',
-    cafile: process.env.NPM_CONFIG_CAFILE || null,
     'package-lock': false,
     'strict-ssl': true,
     registry: getDefaultRegistry(),

--- a/tests/unit/src/__snapshots__/utils.spec.ts.snap
+++ b/tests/unit/src/__snapshots__/utils.spec.ts.snap
@@ -17,27 +17,6 @@ Object {
 }
 `;
 
-exports[`utils .prepareNpmEnv should be able to set cafile 1`] = `
-Array [
-  Object {
-    "nodePath": "node-bin",
-    "npmPath": "npm-bin",
-  },
-  Object {
-    "audit": false,
-    "cafile": "/fake/path",
-    "fund": false,
-    "json": false,
-    "noproxy": "registry.npmjs.org",
-    "package-lock": false,
-    "registry": "test.cafile",
-    "save": false,
-    "strict-ssl": true,
-    "update-notifier": false,
-  },
-]
-`;
-
 exports[`utils .prepareNpmEnv should be able to set strictSSL to false 1`] = `
 Array [
   Object {
@@ -46,7 +25,6 @@ Array [
   },
   Object {
     "audit": false,
-    "cafile": null,
     "fund": false,
     "json": false,
     "noproxy": "registry.npmjs.org",
@@ -67,7 +45,6 @@ Array [
   },
   Object {
     "audit": false,
-    "cafile": null,
     "fund": false,
     "json": false,
     "noproxy": "registry.npmjs.org",
@@ -100,7 +77,6 @@ Array [
   },
   Object {
     "audit": false,
-    "cafile": null,
     "fund": false,
     "json": false,
     "noproxy": "registry.npmjs.org",
@@ -121,7 +97,6 @@ Array [
   },
   Object {
     "audit": false,
-    "cafile": null,
     "fund": false,
     "json": false,
     "noproxy": "registry.npmjs.org",
@@ -142,7 +117,6 @@ Array [
   },
   Object {
     "audit": false,
-    "cafile": null,
     "fund": false,
     "json": false,
     "noproxy": "registry.npmjs.org",
@@ -185,7 +159,6 @@ Array [
   },
   Object {
     "audit": false,
-    "cafile": null,
     "fund": false,
     "json": false,
     "noproxy": "registry.npmjs.org",
@@ -206,7 +179,6 @@ Array [
   },
   Object {
     "audit": false,
-    "cafile": null,
     "fund": false,
     "json": false,
     "noproxy": "registry.npmjs.org",
@@ -227,7 +199,6 @@ Array [
   },
   Object {
     "audit": false,
-    "cafile": null,
     "fund": false,
     "json": false,
     "noproxy": "registry.npmjs.org",

--- a/tests/unit/src/utils.spec.ts
+++ b/tests/unit/src/utils.spec.ts
@@ -195,15 +195,6 @@ describe('utils', function () {
       await prepareNpmEnv(cfg, nodeCtx);
       expect(loadSpyOn.mock.calls[loadSpyOn.mock.calls.length - 1]).toMatchSnapshot();
     });
-    it('should be able to set cafile', async function () {
-      const cfg = _.cloneDeep(runCfg);
-      cfg.npm ||= {};
-      cfg.npm.registry = 'test.cafile';
-      process.env.NPM_CONFIG_CAFILE = '/fake/path';
-      const loadSpyOn = jest.spyOn(npm, 'configure');
-      await prepareNpmEnv(cfg, nodeCtx);
-      expect(loadSpyOn.mock.calls[loadSpyOn.mock.calls.length - 1]).toMatchSnapshot();
-    });
     it('should use rebuild node_modules', async function () {
       const rebuildSpyOn = jest.spyOn(npm, 'rebuild');
       const statSyncSpyOn = jest.spyOn(fs, 'statSync');


### PR DESCRIPTION
Now `cafile` is set in `chef` with an env var `npm_config_cafile`. Remove the setting here and just pick the env var from chef.