### PR TITLE
feat: add option to use globally installed npm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sauce-testrunner-utils",
-  "version": "3.0.1-beta.0",
+  "version": "3.0.2-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sauce-testrunner-utils",
-      "version": "3.0.1-beta.0",
+      "version": "3.0.2-beta.0",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sauce-testrunner-utils",
-  "version": "3.0.0",
+  "version": "3.0.1-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sauce-testrunner-utils",
-      "version": "3.0.0",
+      "version": "3.0.1-beta.0",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sauce-testrunner-utils",
-  "version": "3.0.2-beta.0",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sauce-testrunner-utils",
-      "version": "3.0.2-beta.0",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21",
@@ -2366,7 +2366,8 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -2555,6 +2556,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -2757,6 +2759,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -2787,6 +2790,7 @@
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
       "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2921,7 +2925,8 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
     },
     "node_modules/config-chain": {
       "version": "1.1.13",
@@ -4187,7 +4192,8 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -4207,6 +4213,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -4372,6 +4379,7 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -4403,6 +4411,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -4412,6 +4421,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -4525,7 +4535,8 @@
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true
     },
     "node_modules/graphemer": {
       "version": "1.4.0",
@@ -4546,6 +4557,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -4605,6 +4617,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -4615,7 +4628,8 @@
     "node_modules/hosted-git-info": {
       "version": "2.8.9",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+      "dev": true
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -4781,6 +4795,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
       "engines": {
         "node": ">=0.8.19"
       }
@@ -4790,6 +4805,7 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -4798,12 +4814,14 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "node_modules/ini": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
       "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       }
@@ -5068,6 +5086,7 @@
       "version": "2.13.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
       "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
+      "dev": true,
       "dependencies": {
         "hasown": "^2.0.0"
       },
@@ -5460,7 +5479,8 @@
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
     },
     "node_modules/issue-parser": {
       "version": "7.0.0",
@@ -6190,7 +6210,8 @@
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -6574,6 +6595,7 @@
       "version": "9.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
       "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
+      "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -6597,6 +6619,7 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -6613,7 +6636,8 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
     },
     "node_modules/mute-stream": {
       "version": "1.0.0",
@@ -6725,6 +6749,7 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
       "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
       "dependencies": {
         "hosted-git-info": "^2.1.4",
         "resolve": "^1.10.0",
@@ -6736,6 +6761,7 @@
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
       "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
       "bin": {
         "semver": "bin/semver"
       }
@@ -9399,6 +9425,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -9778,6 +9805,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9794,7 +9822,8 @@
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
     },
     "node_modules/path-scurry": {
       "version": "1.11.1",
@@ -10550,6 +10579,7 @@
       "version": "1.22.8",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
       "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+      "dev": true,
       "dependencies": {
         "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
@@ -10812,6 +10842,7 @@
       "version": "7.6.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
       "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -10934,7 +10965,8 @@
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
@@ -11021,6 +11053,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
       "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
+      "dev": true,
       "dependencies": {
         "spdx-expression-parse": "^3.0.0",
         "spdx-license-ids": "^3.0.0"
@@ -11029,12 +11062,14 @@
     "node_modules/spdx-exceptions": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
-      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w=="
+      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+      "dev": true
     },
     "node_modules/spdx-expression-parse": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
       "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
       "dependencies": {
         "spdx-exceptions": "^2.1.0",
         "spdx-license-ids": "^3.0.0"
@@ -11043,7 +11078,8 @@
     "node_modules/spdx-license-ids": {
       "version": "3.0.18",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.18.tgz",
-      "integrity": "sha512-xxRs31BqRYHwiMzudOrpSiHtZ8i/GeionCBDSilhYRj+9gIcI8wCZTlXZKu9vZIVqViP3dcp9qE5G6AlIaD+TQ=="
+      "integrity": "sha512-xxRs31BqRYHwiMzudOrpSiHtZ8i/GeionCBDSilhYRj+9gIcI8wCZTlXZKu9vZIVqViP3dcp9qE5G6AlIaD+TQ==",
+      "dev": true
     },
     "node_modules/sprintf-js": {
       "version": "1.1.3",
@@ -11271,6 +11307,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -11282,6 +11319,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -11344,7 +11382,8 @@
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true
     },
     "node_modules/tmp": {
       "version": "0.0.33",
@@ -11777,6 +11816,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
       "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
       "dependencies": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
@@ -11813,6 +11853,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -11988,12 +12029,14 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
     },
     "node_modules/write-file-atomic": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
       "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
+      "dev": true,
       "dependencies": {
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.7"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sauce-testrunner-utils",
-  "version": "3.0.2-beta.0",
+  "version": "3.0.0",
   "description": "Sauce Labs test runner helper libary.",
   "author": "devx <dev@saucelabs.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sauce-testrunner-utils",
-  "version": "3.0.0",
+  "version": "3.0.1-beta.0",
   "description": "Sauce Labs test runner helper libary.",
   "author": "devx <dev@saucelabs.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sauce-testrunner-utils",
-  "version": "3.0.1-beta.0",
+  "version": "3.0.2-beta.0",
   "description": "Sauce Labs test runner helper libary.",
   "author": "devx <dev@saucelabs.com>",
   "license": "MIT",

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -39,7 +39,10 @@ export default class NPM {
 
     let p;
 
-    if (nodeCtx.nodePath == 'node' && nodeCtx.npmPath == 'npm') {
+    if (
+      nodeCtx.nodePath.startsWith('node') &&
+      nodeCtx.npmPath.startsWith('npm')
+    ) {
       p = spawn(nodeCtx.npmPath, ['install', ...pkgs]);
     } else {
       p = spawn(nodeCtx.nodePath, [nodeCtx.npmPath, 'install', ...pkgs]);
@@ -71,7 +74,10 @@ export default class NPM {
 
       let p;
 
-      if (nodeCtx.nodePath == 'node' && nodeCtx.npmPath == 'npm') {
+      if (
+        nodeCtx.nodePath.startsWith('node') &&
+        nodeCtx.npmPath.startsWith('npm')
+      ) {
         p = spawn(nodeCtx.npmPath, ['config', 'set', ...args]);
       } else {
         p = spawn(nodeCtx.nodePath, [
@@ -96,7 +102,10 @@ export default class NPM {
   ): Promise<number | null> {
     return new Promise((resolve) => {
       let p;
-      if (nodeCtx.nodePath == 'node' && nodeCtx.npmPath == 'npm') {
+      if (
+        nodeCtx.nodePath.startsWith('node') &&
+        nodeCtx.npmPath.startsWith('npm')
+      ) {
         p = spawn(nodeCtx.npmPath, ['rebuild', ...args]);
       } else {
         p = spawn(nodeCtx.nodePath, [nodeCtx.npmPath, 'rebuild', ...args]);

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -39,11 +39,8 @@ export default class NPM {
 
     let p;
 
-    if (
-      nodeCtx.nodePath.startsWith('node') &&
-      nodeCtx.npmPath.startsWith('npm')
-    ) {
-      p = spawn(nodeCtx.npmPath, ['install', ...pkgs], { shell: true });
+    if (nodeCtx.useGlobals) {
+      p = spawn("npm", ['install', ...pkgs], { shell: true });
     } else {
       p = spawn(nodeCtx.nodePath, [nodeCtx.npmPath, 'install', ...pkgs]);
     }
@@ -74,11 +71,8 @@ export default class NPM {
 
       let p;
 
-      if (
-        nodeCtx.nodePath.startsWith('node') &&
-        nodeCtx.npmPath.startsWith('npm')
-      ) {
-        p = spawn(nodeCtx.npmPath, ['config', 'set', ...args], { shell: true });
+      if (nodeCtx.useGlobals) {
+        p = spawn("npm", ['config', 'set', ...args], { shell: true });
       } else {
         p = spawn(nodeCtx.nodePath, [
           nodeCtx.npmPath,
@@ -102,11 +96,8 @@ export default class NPM {
   ): Promise<number | null> {
     return new Promise((resolve) => {
       let p;
-      if (
-        nodeCtx.nodePath.startsWith('node') &&
-        nodeCtx.npmPath.startsWith('npm')
-      ) {
-        p = spawn(nodeCtx.npmPath, ['rebuild', ...args], { shell: true });
+      if (nodeCtx.useGlobals) {
+        p = spawn("npm", ['rebuild', ...args], { shell: true });
       } else {
         p = spawn(nodeCtx.nodePath, [nodeCtx.npmPath, 'rebuild', ...args]);
       }

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -36,7 +36,14 @@ export default class NPM {
 
   public static async install(nodeCtx: NodeContext, pkgs: string[]) {
     await this.renamePackageJson();
-    const p = spawn(nodeCtx.nodePath, [nodeCtx.npmPath, 'install', ...pkgs]);
+
+    let p;
+
+    if (nodeCtx.nodePath == 'node' && nodeCtx.npmPath == 'npm') {
+      p = spawn(nodeCtx.npmPath, ['install', ...pkgs]);
+    } else {
+      p = spawn(nodeCtx.nodePath, [nodeCtx.npmPath, 'install', ...pkgs]);
+    }
     p.stdout.pipe(process.stdout);
     p.stderr.pipe(process.stderr);
 
@@ -61,12 +68,23 @@ export default class NPM {
       const args = Object.keys(cfg)
         .filter((k) => cfg[k] !== null && cfg[k] !== undefined)
         .map((k) => `${k}=${cfg[k]}`);
-      const p = spawn(nodeCtx.nodePath, [
-        nodeCtx.npmPath,
-        'config',
-        'set',
-        ...args,
-      ]);
+
+      let p;
+
+      if (nodeCtx.nodePath == 'node' && nodeCtx.npmPath == 'npm') {
+        p = spawn(nodeCtx.npmPath, [
+          'config',
+          'set',
+          ...args,
+        ]);
+      } else {
+         p = spawn(nodeCtx.nodePath, [
+          nodeCtx.npmPath,
+          'config',
+          'set',
+          ...args,
+        ]);
+      }
       p.stdout.pipe(process.stdout);
       p.stderr.pipe(process.stderr);
       p.on('exit', () => {
@@ -81,7 +99,12 @@ export default class NPM {
     ...args: string[]
   ): Promise<number | null> {
     return new Promise((resolve) => {
-      const p = spawn(nodeCtx.nodePath, [nodeCtx.npmPath, 'rebuild', ...args]);
+      let p;
+      if (nodeCtx.nodePath == 'node' && nodeCtx.npmPath == 'npm') {
+        p = spawn(nodeCtx.npmPath, ['rebuild', ...args]);
+      } else {
+        p = spawn(nodeCtx.nodePath, [nodeCtx.npmPath, 'rebuild', ...args]);
+      }
       p.stdout.pipe(process.stdout);
       p.stderr.pipe(process.stderr);
       p.on('exit', (exitCode) => {

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -72,13 +72,9 @@ export default class NPM {
       let p;
 
       if (nodeCtx.nodePath == 'node' && nodeCtx.npmPath == 'npm') {
-        p = spawn(nodeCtx.npmPath, [
-          'config',
-          'set',
-          ...args,
-        ]);
+        p = spawn(nodeCtx.npmPath, ['config', 'set', ...args]);
       } else {
-         p = spawn(nodeCtx.nodePath, [
+        p = spawn(nodeCtx.nodePath, [
           nodeCtx.npmPath,
           'config',
           'set',

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -43,7 +43,7 @@ export default class NPM {
       nodeCtx.nodePath.startsWith('node') &&
       nodeCtx.npmPath.startsWith('npm')
     ) {
-      p = spawn(nodeCtx.npmPath, ['install', ...pkgs]);
+      p = spawn(nodeCtx.npmPath, ['install', ...pkgs], { shell: true });
     } else {
       p = spawn(nodeCtx.nodePath, [nodeCtx.npmPath, 'install', ...pkgs]);
     }
@@ -78,7 +78,7 @@ export default class NPM {
         nodeCtx.nodePath.startsWith('node') &&
         nodeCtx.npmPath.startsWith('npm')
       ) {
-        p = spawn(nodeCtx.npmPath, ['config', 'set', ...args]);
+        p = spawn(nodeCtx.npmPath, ['config', 'set', ...args], { shell: true });
       } else {
         p = spawn(nodeCtx.nodePath, [
           nodeCtx.npmPath,
@@ -106,7 +106,7 @@ export default class NPM {
         nodeCtx.nodePath.startsWith('node') &&
         nodeCtx.npmPath.startsWith('npm')
       ) {
-        p = spawn(nodeCtx.npmPath, ['rebuild', ...args]);
+        p = spawn(nodeCtx.npmPath, ['rebuild', ...args], { shell: true });
       } else {
         p = spawn(nodeCtx.nodePath, [nodeCtx.npmPath, 'rebuild', ...args]);
       }

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -40,7 +40,7 @@ export default class NPM {
     let p;
 
     if (nodeCtx.useGlobals) {
-      p = spawn("npm", ['install', ...pkgs], { shell: true });
+      p = spawn('npm', ['install', ...pkgs], { shell: true });
     } else {
       p = spawn(nodeCtx.nodePath, [nodeCtx.npmPath, 'install', ...pkgs]);
     }
@@ -72,7 +72,7 @@ export default class NPM {
       let p;
 
       if (nodeCtx.useGlobals) {
-        p = spawn("npm", ['config', 'set', ...args], { shell: true });
+        p = spawn('npm', ['config', 'set', ...args], { shell: true });
       } else {
         p = spawn(nodeCtx.nodePath, [
           nodeCtx.npmPath,
@@ -97,7 +97,7 @@ export default class NPM {
     return new Promise((resolve) => {
       let p;
       if (nodeCtx.useGlobals) {
-        p = spawn("npm", ['rebuild', ...args], { shell: true });
+        p = spawn('npm', ['rebuild', ...args], { shell: true });
       } else {
         p = spawn(nodeCtx.nodePath, [nodeCtx.npmPath, 'rebuild', ...args]);
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,5 +46,5 @@ export interface NodeContext {
 
   // Ignore the specific binary paths provided and rely on the binaries
   // from PATH.
-  useGlobals: boolean;
+  useGlobals?: boolean;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,4 +43,8 @@ export interface SuitesContainer {
 export interface NodeContext {
   nodePath: string;
   npmPath: string;
+
+  // Ignore the specific binary paths provided and rely on the binaries
+  // from PATH.
+  useGlobals: boolean;
 }

--- a/tests/unit/src/__snapshots__/utils.spec.ts.snap
+++ b/tests/unit/src/__snapshots__/utils.spec.ts.snap
@@ -22,6 +22,7 @@ exports[`utils .prepareNpmEnv should be able to set strictSSL to false 1`] = `
   {
     "nodePath": "node-bin",
     "npmPath": "npm-bin",
+    "useGlobals": false,
   },
   {
     "audit": false,
@@ -43,6 +44,7 @@ exports[`utils .prepareNpmEnv should be able to set strictSSL to true 1`] = `
   {
     "nodePath": "node-bin",
     "npmPath": "npm-bin",
+    "useGlobals": false,
   },
   {
     "audit": false,
@@ -64,6 +66,7 @@ exports[`utils .prepareNpmEnv should call npm install 1`] = `
   {
     "nodePath": "node-bin",
     "npmPath": "npm-bin",
+    "useGlobals": false,
   },
   [
     "mypackage@1.2.3",
@@ -76,6 +79,7 @@ exports[`utils .prepareNpmEnv should set right registry for npm 1`] = `
   {
     "nodePath": "node-bin",
     "npmPath": "npm-bin",
+    "useGlobals": false,
   },
   {
     "audit": false,
@@ -96,6 +100,7 @@ exports[`utils .prepareNpmEnv should use default registry 1`] = `
   {
     "nodePath": "node-bin",
     "npmPath": "npm-bin",
+    "useGlobals": false,
   },
   {
     "audit": false,
@@ -117,6 +122,7 @@ exports[`utils .prepareNpmEnv should use env var for registry 1`] = `
   {
     "nodePath": "node-bin",
     "npmPath": "npm-bin",
+    "useGlobals": false,
   },
   {
     "audit": false,
@@ -138,6 +144,7 @@ exports[`utils .prepareNpmEnv should use rebuild node_modules 1`] = `
   {
     "nodePath": "node-bin",
     "npmPath": "npm-bin",
+    "useGlobals": false,
   },
   "--prefix",
   "/fake/runner",
@@ -149,6 +156,7 @@ exports[`utils .prepareNpmEnv should use rebuild node_modules when not package i
   {
     "nodePath": "node-bin",
     "npmPath": "npm-bin",
+    "useGlobals": false,
   },
   "--prefix",
   "/fake/runner",
@@ -160,6 +168,7 @@ exports[`utils .prepareNpmEnv should use true as the default value for strictSSL
   {
     "nodePath": "node-bin",
     "npmPath": "npm-bin",
+    "useGlobals": false,
   },
   {
     "audit": false,
@@ -181,6 +190,7 @@ exports[`utils .prepareNpmEnv should use true as the default value for strictSSL
   {
     "nodePath": "node-bin",
     "npmPath": "npm-bin",
+    "useGlobals": false,
   },
   {
     "audit": false,
@@ -202,6 +212,7 @@ exports[`utils .prepareNpmEnv should use user registry 1`] = `
   {
     "nodePath": "node-bin",
     "npmPath": "npm-bin",
+    "useGlobals": false,
   },
   {
     "audit": false,

--- a/tests/unit/src/npm.spec.ts
+++ b/tests/unit/src/npm.spec.ts
@@ -4,13 +4,18 @@ import { Stats } from 'fs';
 
 jest.mock('fs/promises');
 import fs from 'fs/promises';
+
 const fsMocked = fs as jest.Mocked<typeof fs>;
 
 import NPM from '../../../src/npm';
 import { NodeContext } from '../../../src/types';
 
 describe('NPM', function () {
-  const nodeCtx: NodeContext = { nodePath: 'node-bin', npmPath: 'npm-bin' };
+  const nodeCtx: NodeContext = {
+    nodePath: 'node-bin',
+    npmPath: 'npm-bin',
+    useGlobals: false,
+  };
 
   beforeEach(function () {
     spawk.load();

--- a/tests/unit/src/utils.spec.ts
+++ b/tests/unit/src/utils.spec.ts
@@ -31,7 +31,11 @@ import {
 } from '../../../src/types';
 
 describe('utils', function () {
-  const nodeCtx: NodeContext = { nodePath: 'node-bin', npmPath: 'npm-bin' };
+  const nodeCtx: NodeContext = {
+    nodePath: 'node-bin',
+    npmPath: 'npm-bin',
+    useGlobals: false,
+  };
 
   describe('.getNpmConfig', function () {
     const emptyConfig = {


### PR DESCRIPTION
## Description

Add the option to use the globally installed `npm`.

`spawn` must be invoked with `shell: true` for Windows, it is otherwise unable to spawn a direct process of `npm.cmd` and requires a shell for interpretation.