### PR TITLE
fix: Support unset strictSSL setting

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -22,7 +22,7 @@ export type NpmConfig = {
    */
   registry?: string;
   registries?: Registry[];
-  strictSSL?: boolean | string | null;
+  strictSSL?: boolean | null;
   packageLock?: boolean | string | null;
   packages?: { [key: string]: string | number };
   legacyPeerDeps?: boolean | string | null;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -59,7 +59,6 @@ export async function setUpNpmConfig(
     fund: false,
     noproxy: 'registry.npmjs.org',
     'package-lock': false,
-    'strict-ssl': true,
     registry: getDefaultRegistry(),
     'update-notifier': false,
   };
@@ -129,7 +128,7 @@ export function getNpmConfig(runnerConfig: NpmConfigContainer) {
   if (runnerConfig.npm === undefined) {
     return {};
   }
-  const cfg: { [key: string]: string | boolean | null } = {
+  const cfg: { [key: string]: string | boolean | null | undefined } = {
     registry: runnerConfig.npm.registry || getDefaultRegistry(),
     'strict-ssl': runnerConfig.npm.strictSSL,
     // Setting to false to avoid dealing with the generated file.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -131,7 +131,7 @@ export function getNpmConfig(runnerConfig: NpmConfigContainer) {
   }
   const cfg: { [key: string]: string | boolean | null } = {
     registry: runnerConfig.npm.registry || getDefaultRegistry(),
-    'strict-ssl': runnerConfig.npm.strictSSL ?? null,
+    'strict-ssl': runnerConfig.npm.strictSSL,
     // Setting to false to avoid dealing with the generated file.
     'package-lock': runnerConfig.npm.packageLock === true,
     'legacy-peer-deps':

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -131,7 +131,7 @@ export function getNpmConfig(runnerConfig: NpmConfigContainer) {
   }
   const cfg: { [key: string]: string | boolean | null } = {
     registry: runnerConfig.npm.registry || getDefaultRegistry(),
-    'strict-ssl': runnerConfig.npm.strictSSL !== false,
+    'strict-ssl': runnerConfig.npm.strictSSL ?? null,
     // Setting to false to avoid dealing with the generated file.
     'package-lock': runnerConfig.npm.packageLock === true,
     'legacy-peer-deps':

--- a/tests/unit/src/__snapshots__/utils.spec.ts.snap
+++ b/tests/unit/src/__snapshots__/utils.spec.ts.snap
@@ -111,7 +111,7 @@ exports[`utils .prepareNpmEnv should use default registry 1`] = `
     "package-lock": false,
     "registry": "https://registry.npmjs.org",
     "save": false,
-    "strict-ssl": true,
+    "strict-ssl": null,
     "update-notifier": false,
   },
 ]
@@ -133,7 +133,7 @@ exports[`utils .prepareNpmEnv should use env var for registry 1`] = `
     "package-lock": false,
     "registry": "npmland.io",
     "save": false,
-    "strict-ssl": true,
+    "strict-ssl": null,
     "update-notifier": false,
   },
 ]
@@ -179,7 +179,7 @@ exports[`utils .prepareNpmEnv should use true as the default value for strictSSL
     "package-lock": false,
     "registry": "https://registry.npmjs.org",
     "save": false,
-    "strict-ssl": true,
+    "strict-ssl": null,
     "update-notifier": false,
   },
 ]
@@ -201,7 +201,7 @@ exports[`utils .prepareNpmEnv should use true as the default value for strictSSL
     "package-lock": false,
     "registry": "https://registry.npmjs.org",
     "save": false,
-    "strict-ssl": true,
+    "strict-ssl": null,
     "update-notifier": false,
   },
 ]
@@ -223,7 +223,7 @@ exports[`utils .prepareNpmEnv should use user registry 1`] = `
     "package-lock": false,
     "registry": "registryland.io",
     "save": false,
-    "strict-ssl": true,
+    "strict-ssl": null,
     "update-notifier": false,
   },
 ]

--- a/tests/unit/src/__snapshots__/utils.spec.ts.snap
+++ b/tests/unit/src/__snapshots__/utils.spec.ts.snap
@@ -111,7 +111,7 @@ exports[`utils .prepareNpmEnv should use default registry 1`] = `
     "package-lock": false,
     "registry": "https://registry.npmjs.org",
     "save": false,
-    "strict-ssl": null,
+    "strict-ssl": undefined,
     "update-notifier": false,
   },
 ]
@@ -133,7 +133,7 @@ exports[`utils .prepareNpmEnv should use env var for registry 1`] = `
     "package-lock": false,
     "registry": "npmland.io",
     "save": false,
-    "strict-ssl": null,
+    "strict-ssl": undefined,
     "update-notifier": false,
   },
 ]
@@ -179,7 +179,7 @@ exports[`utils .prepareNpmEnv should use true as the default value for strictSSL
     "package-lock": false,
     "registry": "https://registry.npmjs.org",
     "save": false,
-    "strict-ssl": null,
+    "strict-ssl": undefined,
     "update-notifier": false,
   },
 ]
@@ -201,7 +201,7 @@ exports[`utils .prepareNpmEnv should use true as the default value for strictSSL
     "package-lock": false,
     "registry": "https://registry.npmjs.org",
     "save": false,
-    "strict-ssl": null,
+    "strict-ssl": undefined,
     "update-notifier": false,
   },
 ]
@@ -223,7 +223,7 @@ exports[`utils .prepareNpmEnv should use user registry 1`] = `
     "package-lock": false,
     "registry": "registryland.io",
     "save": false,
-    "strict-ssl": null,
+    "strict-ssl": undefined,
     "update-notifier": false,
   },
 ]

--- a/tests/unit/src/utils.spec.ts
+++ b/tests/unit/src/utils.spec.ts
@@ -56,9 +56,9 @@ describe('utils', function () {
       expect(npmConfig).toHaveProperty('package-lock');
     });
 
-    it('should set strictSSL to null if not set', function () {
+    it('should set strictSSL to undefined if not set', function () {
       const npmConfig = getNpmConfig(emptyConfig);
-      expect(npmConfig).toHaveProperty('strict-ssl', null);
+      expect(npmConfig).toHaveProperty('strict-ssl', undefined);
     });
 
     it('should set strictSSL from runner config', function () {

--- a/tests/unit/src/utils.spec.ts
+++ b/tests/unit/src/utils.spec.ts
@@ -56,9 +56,9 @@ describe('utils', function () {
       expect(npmConfig).toHaveProperty('package-lock');
     });
 
-    it('should set strictSSL to true by default', function () {
+    it('should set strictSSL to null if not set', function () {
       const npmConfig = getNpmConfig(emptyConfig);
-      expect(npmConfig).toHaveProperty('strict-ssl', true);
+      expect(npmConfig).toHaveProperty('strict-ssl', null);
     });
 
     it('should set strictSSL from runner config', function () {
@@ -72,10 +72,6 @@ describe('utils', function () {
 
       runnerConfig.npm ||= {};
       runnerConfig.npm.strictSSL = true;
-      npmConfig = getNpmConfig(runnerConfig);
-      expect(npmConfig).toHaveProperty('strict-ssl', true);
-
-      runnerConfig.npm.strictSSL = 'truthy?';
       npmConfig = getNpmConfig(runnerConfig);
       expect(npmConfig).toHaveProperty('strict-ssl', true);
     });


### PR DESCRIPTION
## Description
<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

Let strictSSL field nullable and use npm default settings.

strictSSL not set: https://app.saucelabs.com/tests/22db9a3effdc4d9cbd005839403df483
strictSSL is true: https://app.saucelabs.com/tests/5a57b6dc937c447ea22852c63d5d97c7
strictSSL is false: https://app.saucelabs.com/tests/1ac681507c9a4a8da2f14b1deb6169d9