### PR TITLE
feat: Conditionally rename package(-lock)?.json based on config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sauce-testrunner-utils",
-  "version": "3.2.2-alpha.0",
+  "version": "3.2.2-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sauce-testrunner-utils",
-      "version": "3.2.2-alpha.0",
+      "version": "3.2.2-alpha.1",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sauce-testrunner-utils",
-  "version": "3.2.1",
+  "version": "3.2.2-alpha.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sauce-testrunner-utils",
-      "version": "3.2.1",
+      "version": "3.2.2-alpha.0",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sauce-testrunner-utils",
-  "version": "3.2.1",
+  "version": "3.2.2-alpha.0",
   "description": "Sauce Labs test runner helper libary.",
   "author": "devx <dev@saucelabs.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sauce-testrunner-utils",
-  "version": "3.2.2-alpha.0",
+  "version": "3.2.2-alpha.1",
   "description": "Sauce Labs test runner helper libary.",
   "author": "devx <dev@saucelabs.com>",
   "license": "MIT",

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -35,8 +35,6 @@ export default class NPM {
   }
 
   public static async install(nodeCtx: NodeContext, pkgs: string[]) {
-    await this.renamePackageJson();
-
     let p;
 
     if (nodeCtx.useGlobals) {

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -53,8 +53,6 @@ export default class NPM {
 
     const exitCode = await exitPromise;
 
-    await this.restorePackageJson();
-
     return exitCode;
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,7 @@ export type NpmConfig = {
   packageLock?: boolean | string | null;
   packages?: { [key: string]: string | number };
   legacyPeerDeps?: boolean | string | null;
+  usePackageLock?: boolean;
 };
 
 export interface PathContainer {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -208,6 +208,9 @@ export async function prepareNpmEnv(
   );
 
   // install npm packages
+  if (runCfg.npm?.usePackageLock !== true) {
+    await npm.renamePackageJson();
+  }
   startTime = new Date().getTime();
   await installNpmDependencies(nodeCtx, fixedPackageList);
   endTime = new Date().getTime();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -198,10 +198,6 @@ export async function prepareNpmEnv(
     npmMetrics.data.rebuild = { duration: endTime - startTime };
   }
 
-  if (Object.keys(packageList).length === 0) {
-    return npmMetrics;
-  }
-
   // Ensure version is a string value as NPM only accepts strings.
   const fixedPackageList = Object.fromEntries(
     Object.entries(packageList).map(([k, v]) => [k, String(v)]),
@@ -209,11 +205,17 @@ export async function prepareNpmEnv(
 
   // install npm packages
   if (runCfg.npm?.usePackageLock !== true) {
+    if (Object.keys(fixedPackageList).length === 0) {
+      return npmMetrics;
+    }
+
     await npm.renamePackageJson();
   }
   startTime = new Date().getTime();
   await installNpmDependencies(nodeCtx, fixedPackageList);
   endTime = new Date().getTime();
+
+  await npm.restorePackageJson();
   npmMetrics.data.install = { duration: endTime - startTime };
   return npmMetrics;
 }

--- a/tests/unit/src/npm.spec.ts
+++ b/tests/unit/src/npm.spec.ts
@@ -1,6 +1,6 @@
 import spawk from 'spawk';
 
-import { Stats } from 'fs';
+// import { Stats } from 'fs';
 
 jest.mock('fs/promises');
 import fs from 'fs/promises';
@@ -70,38 +70,38 @@ describe('NPM', function () {
       'install',
       'cypress@12.6.0',
     ]);
-    expect(fsMocked.lstat).toBeCalledTimes(4);
+    // expect(fsMocked.lstat).toBeCalledTimes(4);
   });
 
-  it('.install moves package.json / package-lock.json', async function () {
-    const interceptor = spawk
-      .spawn(nodeCtx.nodePath)
-      .stdout('npm runned')
-      .exit(0);
-    fsMocked.lstat.mockRejectedValue('non-existing');
+  // it('.install moves package.json / package-lock.json', async function () {
+  //   const interceptor = spawk
+  //     .spawn(nodeCtx.nodePath)
+  //     .stdout('npm runned')
+  //     .exit(0);
+  //   fsMocked.lstat.mockRejectedValue('non-existing');
 
-    fsMocked.lstat.mockResolvedValue({} as Stats);
-    fsMocked.rename.mockResolvedValue();
-    fsMocked.writeFile.mockResolvedValue();
+  //   fsMocked.lstat.mockResolvedValue({} as Stats);
+  //   fsMocked.rename.mockResolvedValue();
+  //   fsMocked.writeFile.mockResolvedValue();
 
-    await NPM.install(nodeCtx, ['cypress@12.6.0']);
-    expect(interceptor.calledWith.command).toEqual(nodeCtx.nodePath);
-    expect(interceptor.calledWith.args).toEqual([
-      nodeCtx.npmPath,
-      'install',
-      'cypress@12.6.0',
-    ]);
-    expect(fsMocked.rename.mock.calls).toEqual([
-      ['package.json', `.package.json-${process.pid}`],
-      ['package-lock.json', `.package-lock.json-${process.pid}`],
-      [`.package.json-${process.pid}`, 'package.json'],
-      [`.package-lock.json-${process.pid}`, 'package-lock.json'],
-    ]);
-    expect(fsMocked.lstat.mock.calls).toEqual([
-      ['package.json'],
-      ['package-lock.json'],
-      [`.package.json-${process.pid}`],
-      [`.package-lock.json-${process.pid}`],
-    ]);
-  });
+  //   await NPM.install(nodeCtx, ['cypress@12.6.0']);
+  //   expect(interceptor.calledWith.command).toEqual(nodeCtx.nodePath);
+  //   expect(interceptor.calledWith.args).toEqual([
+  //     nodeCtx.npmPath,
+  //     'install',
+  //     'cypress@12.6.0',
+  //   ]);
+  //   expect(fsMocked.rename.mock.calls).toEqual([
+  //     ['package.json', `.package.json-${process.pid}`],
+  //     ['package-lock.json', `.package-lock.json-${process.pid}`],
+  //     [`.package.json-${process.pid}`, 'package.json'],
+  //     [`.package-lock.json-${process.pid}`, 'package-lock.json'],
+  //   ]);
+  //   expect(fsMocked.lstat.mock.calls).toEqual([
+  //     ['package.json'],
+  //     ['package-lock.json'],
+  //     [`.package.json-${process.pid}`],
+  //     [`.package-lock.json-${process.pid}`],
+  //   ]);
+  // });
 });

--- a/tests/unit/src/npm.spec.ts
+++ b/tests/unit/src/npm.spec.ts
@@ -1,6 +1,5 @@
 import spawk from 'spawk';
 
-// import { Stats } from 'fs';
 
 jest.mock('fs/promises');
 import fs from 'fs/promises';

--- a/tests/unit/src/npm.spec.ts
+++ b/tests/unit/src/npm.spec.ts
@@ -70,38 +70,5 @@ describe('NPM', function () {
       'install',
       'cypress@12.6.0',
     ]);
-    // expect(fsMocked.lstat).toBeCalledTimes(4);
   });
-
-  // it('.install moves package.json / package-lock.json', async function () {
-  //   const interceptor = spawk
-  //     .spawn(nodeCtx.nodePath)
-  //     .stdout('npm runned')
-  //     .exit(0);
-  //   fsMocked.lstat.mockRejectedValue('non-existing');
-
-  //   fsMocked.lstat.mockResolvedValue({} as Stats);
-  //   fsMocked.rename.mockResolvedValue();
-  //   fsMocked.writeFile.mockResolvedValue();
-
-  //   await NPM.install(nodeCtx, ['cypress@12.6.0']);
-  //   expect(interceptor.calledWith.command).toEqual(nodeCtx.nodePath);
-  //   expect(interceptor.calledWith.args).toEqual([
-  //     nodeCtx.npmPath,
-  //     'install',
-  //     'cypress@12.6.0',
-  //   ]);
-  //   expect(fsMocked.rename.mock.calls).toEqual([
-  //     ['package.json', `.package.json-${process.pid}`],
-  //     ['package-lock.json', `.package-lock.json-${process.pid}`],
-  //     [`.package.json-${process.pid}`, 'package.json'],
-  //     [`.package-lock.json-${process.pid}`, 'package-lock.json'],
-  //   ]);
-  //   expect(fsMocked.lstat.mock.calls).toEqual([
-  //     ['package.json'],
-  //     ['package-lock.json'],
-  //     [`.package.json-${process.pid}`],
-  //     [`.package-lock.json-${process.pid}`],
-  //   ]);
-  // });
 });

--- a/tests/unit/src/npm.spec.ts
+++ b/tests/unit/src/npm.spec.ts
@@ -1,6 +1,5 @@
 import spawk from 'spawk';
 
-
 jest.mock('fs/promises');
 import fs from 'fs/promises';
 


### PR DESCRIPTION
## Description
<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

Add new npm configuration, `usePackageLock`, that when true uses the provided `package(-lock)?.json` during package installation. Otherwise, fallback to the default behaviour of renaming the files during installation.

[DEVX-3077]


[DEVX-3077]: https://saucedev.atlassian.net/browse/DEVX-3077?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ