### PR TITLE
fix for int-331 | add runWithStdoutWatchdog helper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sauce-testrunner-utils",
-  "version": "3.3.1",
+  "version": "3.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sauce-testrunner-utils",
-      "version": "3.3.1",
+      "version": "3.4.0",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sauce-testrunner-utils",
-  "version": "3.3.1",
+  "version": "3.4.0",
   "description": "Sauce Labs test runner helper libary.",
   "author": "devx <dev@saucelabs.com>",
   "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,8 @@ import * as npm from './npm';
 import * as utils from './utils';
 import * as preExec from './preExec';
 import { zip } from './zip';
+import { runWithStdoutWatchdog } from './watchdog';
+import type { WatchdogOptions, WatchdogResult } from './watchdog';
 import {
   getAbsolutePath,
   shouldRecordVideo,
@@ -27,6 +29,7 @@ export {
   utils,
   preExec,
   zip,
+  runWithStdoutWatchdog,
 
   // Exporting all to keep compatibility with previous API
   getAbsolutePath,
@@ -46,3 +49,5 @@ export {
   renameAsset,
   escapeXML,
 };
+
+export type { WatchdogOptions, WatchdogResult };

--- a/src/watchdog.ts
+++ b/src/watchdog.ts
@@ -1,0 +1,133 @@
+import type { ChildProcess } from 'child_process';
+
+export interface WatchdogOptions {
+  /**
+   * Maximum seconds of stdout/stderr silence from the child before it is
+   * treated as hung. The timer resets on every chunk of output.
+   */
+  noProgressTimeoutSecs: number;
+
+  /**
+   * Milliseconds to wait between SIGTERM and SIGKILL after the watchdog
+   * fires. Defaults to 10000 (10s).
+   */
+  signalEscalationMs?: number;
+
+  /**
+   * Called once when the watchdog fires, before signals are sent. Receives
+   * the time at which the last output chunk was seen.
+   */
+  onStall?: (lastSeenAt: Date) => void;
+
+  /**
+   * Log prefix used in the "no output for Ns" message. Defaults to
+   * "Sauce runner watchdog".
+   */
+  tag?: string;
+}
+
+export interface WatchdogResult {
+  exitCode: number | null;
+  signal: NodeJS.Signals | null;
+  watchdogFired: boolean;
+}
+
+/**
+ * Watch a spawned child process for stdout/stderr silence and terminate it
+ * if no output is produced within `noProgressTimeoutSecs`. Each chunk of
+ * output is echoed to the parent's stdout/stderr so existing logs are
+ * preserved, and the silence timer is reset.
+ *
+ * The child MUST be spawned with piped stdout and stderr (i.e. not
+ * `stdio: 'inherit'`) so the parent can observe its output.
+ */
+export function runWithStdoutWatchdog(
+  child: ChildProcess,
+  opts: WatchdogOptions,
+): Promise<WatchdogResult> {
+  const tag = opts.tag ?? 'Sauce runner watchdog';
+  const escalationMs = opts.signalEscalationMs ?? 10_000;
+  const timeoutMs = opts.noProgressTimeoutSecs * 1000;
+
+  let lastSeenAt = new Date();
+  let watchdogFired = false;
+  let watchdogTimer: NodeJS.Timeout | undefined;
+  let killTimer: NodeJS.Timeout | undefined;
+
+  const resetWatchdog = () => {
+    // Once the watchdog has fired, don't re-arm — late output from a
+    // child that's being terminated should not block the kill sequence
+    // or generate duplicate "no output" log lines.
+    if (watchdogFired) {
+      return;
+    }
+    lastSeenAt = new Date();
+    if (watchdogTimer) {
+      clearTimeout(watchdogTimer);
+    }
+    watchdogTimer = setTimeout(() => {
+      watchdogFired = true;
+      console.error(
+        `${tag}: no output from child for ${opts.noProgressTimeoutSecs}s — terminating.`,
+      );
+      if (opts.onStall) {
+        try {
+          opts.onStall(lastSeenAt);
+        } catch (err) {
+          console.error(`${tag}: onStall handler threw: ${err}`);
+        }
+      }
+      try {
+        child.kill('SIGTERM');
+      } catch (err) {
+        console.error(`${tag}: SIGTERM failed: ${err}`);
+      }
+      killTimer = setTimeout(() => {
+        if (child.exitCode === null && child.signalCode === null) {
+          console.error(`${tag}: child still alive after SIGTERM — SIGKILL.`);
+          try {
+            child.kill('SIGKILL');
+          } catch (err) {
+            console.error(`${tag}: SIGKILL failed: ${err}`);
+          }
+        }
+      }, escalationMs);
+    }, timeoutMs);
+  };
+
+  if (child.stdout) {
+    child.stdout.on('data', (chunk: Buffer | string) => {
+      process.stdout.write(chunk);
+      resetWatchdog();
+    });
+  }
+  if (child.stderr) {
+    child.stderr.on('data', (chunk: Buffer | string) => {
+      process.stderr.write(chunk);
+      resetWatchdog();
+    });
+  }
+
+  resetWatchdog();
+
+  return new Promise<WatchdogResult>((resolve) => {
+    let settled = false;
+    const settle = (code: number | null, signal: NodeJS.Signals | null) => {
+      if (settled) return;
+      settled = true;
+      if (watchdogTimer) {
+        clearTimeout(watchdogTimer);
+      }
+      if (killTimer) {
+        clearTimeout(killTimer);
+      }
+      resolve({ exitCode: code, signal, watchdogFired });
+    };
+    // Listen to 'exit' (fires when the process terminates) rather than only
+    // 'close' (which waits for all stdio streams to flush). Grandchildren
+    // such as Chrome can inherit and hold the parent's pipe FDs open
+    // indefinitely after the parent dies, preventing 'close' from firing.
+    child.on('exit', (code, signal) => settle(code, signal));
+    child.on('close', (code, signal) => settle(code, signal));
+  });
+}

--- a/tests/unit/src/watchdog.spec.ts
+++ b/tests/unit/src/watchdog.spec.ts
@@ -1,0 +1,173 @@
+import childProcess from 'child_process';
+import events from 'events';
+import stream from 'stream';
+import { runWithStdoutWatchdog } from '../../../src/watchdog';
+
+function makeFakeChild() {
+  const fakeProc = <childProcess.ChildProcess>new events.EventEmitter();
+  fakeProc.stdin = new stream.Writable();
+  fakeProc.stdout = <stream.Readable>new events.EventEmitter();
+  fakeProc.stderr = <stream.Readable>new events.EventEmitter();
+  // jest sees `fakeProc.exitCode` / `signalCode` via property access; default null
+  Object.defineProperty(fakeProc, 'exitCode', {
+    value: null,
+    writable: true,
+    configurable: true,
+  });
+  Object.defineProperty(fakeProc, 'signalCode', {
+    value: null,
+    writable: true,
+    configurable: true,
+  });
+  fakeProc.kill = jest.fn().mockReturnValue(true);
+  return fakeProc;
+}
+
+describe('runWithStdoutWatchdog', () => {
+  let writeStdoutSpy: jest.SpyInstance;
+  let writeStderrSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    writeStdoutSpy = jest
+      .spyOn(process.stdout, 'write')
+      .mockImplementation(() => true);
+    writeStderrSpy = jest
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    writeStdoutSpy.mockRestore();
+    writeStderrSpy.mockRestore();
+    jest.useRealTimers();
+  });
+
+  it('resolves with watchdogFired=false when child exits before timeout', async () => {
+    const child = makeFakeChild();
+    const promise = runWithStdoutWatchdog(child, {
+      noProgressTimeoutSecs: 5,
+      tag: 'TEST',
+    });
+
+    setTimeout(() => {
+      child.stdout?.emit('data', Buffer.from('hello\n'));
+      child.emit('close', 0, null);
+    }, 10);
+
+    const result = await promise;
+    expect(result.watchdogFired).toBe(false);
+    expect(result.exitCode).toBe(0);
+    expect(child.kill).not.toHaveBeenCalled();
+  });
+
+  it('fires the watchdog and SIGTERMs the child after stdout silence', async () => {
+    jest.useFakeTimers();
+    const child = makeFakeChild();
+    const onStall = jest.fn();
+
+    const promise = runWithStdoutWatchdog(child, {
+      noProgressTimeoutSecs: 2,
+      signalEscalationMs: 1000,
+      tag: 'TEST',
+      onStall,
+    });
+
+    // Advance past the no-progress window
+    jest.advanceTimersByTime(2_000);
+
+    expect(onStall).toHaveBeenCalledTimes(1);
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+
+    // Child still alive after SIGTERM → SIGKILL after escalation window
+    jest.advanceTimersByTime(1_000);
+    expect(child.kill).toHaveBeenCalledWith('SIGKILL');
+
+    // Simulate close from the kill
+    child.emit('close', null, 'SIGKILL');
+
+    jest.useRealTimers();
+    const result = await promise;
+    expect(result.watchdogFired).toBe(true);
+    expect(result.signal).toBe('SIGKILL');
+  });
+
+  it('resets the silence timer on each chunk of output', async () => {
+    jest.useFakeTimers();
+    const child = makeFakeChild();
+
+    const promise = runWithStdoutWatchdog(child, {
+      noProgressTimeoutSecs: 2,
+      signalEscalationMs: 1000,
+      tag: 'TEST',
+    });
+
+    // 1.5s of silence — should NOT fire yet
+    jest.advanceTimersByTime(1_500);
+    expect(child.kill).not.toHaveBeenCalled();
+
+    // Output resets the timer
+    child.stdout?.emit('data', Buffer.from('tick\n'));
+
+    // Another 1.5s — still under 2s since the chunk; should NOT fire
+    jest.advanceTimersByTime(1_500);
+    expect(child.kill).not.toHaveBeenCalled();
+
+    // Cross the threshold
+    jest.advanceTimersByTime(1_000);
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+
+    child.emit('close', null, 'SIGTERM');
+    jest.useRealTimers();
+    const result = await promise;
+    expect(result.watchdogFired).toBe(true);
+  });
+
+  it('does not re-arm the timer after it has fired', async () => {
+    jest.useFakeTimers();
+    const child = makeFakeChild();
+    const onStall = jest.fn();
+
+    const promise = runWithStdoutWatchdog(child, {
+      noProgressTimeoutSecs: 2,
+      signalEscalationMs: 1000,
+      tag: 'TEST',
+      onStall,
+    });
+
+    // Fire the watchdog
+    jest.advanceTimersByTime(2_000);
+    expect(onStall).toHaveBeenCalledTimes(1);
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+
+    // Late stdout output from the dying child must not re-arm
+    child.stdout?.emit('data', Buffer.from('late chatter from doomed child\n'));
+    jest.advanceTimersByTime(3_000);
+
+    // Still only one stall callback and SIGTERM call (plus SIGKILL escalation)
+    expect(onStall).toHaveBeenCalledTimes(1);
+    expect(child.kill).toHaveBeenCalledWith('SIGKILL');
+    expect((child.kill as jest.Mock).mock.calls.length).toBeLessThanOrEqual(2);
+
+    child.emit('close', null, 'SIGKILL');
+    jest.useRealTimers();
+    await promise;
+  });
+
+  it('echoes stdout and stderr to the parent streams', async () => {
+    const child = makeFakeChild();
+    const promise = runWithStdoutWatchdog(child, {
+      noProgressTimeoutSecs: 5,
+      tag: 'TEST',
+    });
+
+    setTimeout(() => {
+      child.stdout?.emit('data', Buffer.from('out-chunk'));
+      child.stderr?.emit('data', Buffer.from('err-chunk'));
+      child.emit('close', 0, null);
+    }, 10);
+
+    await promise;
+    expect(writeStdoutSpy).toHaveBeenCalledWith(Buffer.from('out-chunk'));
+    expect(writeStderrSpy).toHaveBeenCalledWith(Buffer.from('err-chunk'));
+  });
+});


### PR DESCRIPTION
  **Summary**
 Adds a generic stdout-silence watchdog helper that wraps a spawned child process. If the child produces no output for noProgressTimeoutSecs, the helper logs a clear message, sends SIGTERM (escalating to SIGKILL), and resolves
  with { watchdogFired: true }. Output is echoed through to the parent's streams, so existing log behavior is preserved.

  **Motivation**
Framework runners that consume this package (e.g. sauce-testcafe-runner) spawn their framework subprocess with stdio: 'inherit' and race only a hard outer timeout. When the framework hangs silently — internal ticket INT-331
traced a customer case where a target site returned a 503 with an idle-but-open TCP socket — jobs spin for the full 30-minute budget with no useful error.

Shipping this in the shared utils lets sauce-{testcafe,cypress,playwright}-runner adopt the same defense with a small wiring change.
